### PR TITLE
Add `.js` extension to `./y-range` import

### DIFF
--- a/src/y-sync.js
+++ b/src/y-sync.js
@@ -2,7 +2,7 @@
 import * as Y from 'yjs'
 import { Facet, Annotation, AnnotationType, SelectionRange, EditorSelection } from '@codemirror/state' // eslint-disable-line
 import { ViewPlugin, ViewUpdate, EditorView } from '@codemirror/view' // eslint-disable-line
-import { YRange } from './y-range'
+import { YRange } from './y-range.js'
 
 export class YSyncConfig {
   constructor (ytext, awareness) {


### PR DESCRIPTION
Following https://github.com/yjs/y-codemirror.next/commit/097e9dec1300b2dac7b10146ca0a11a09b140868, my issue in #1 became instead the following:

```
ERROR in ./node_modules/y-codemirror.next/src/y-sync.js 5:0-34
Module not found: Error: Can't resolve './y-range' in '.../node_modules/y-codemirror.next/src'
Did you mean 'y-range.js'?
BREAKING CHANGE: The request './y-range' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

I'm not very familiar at all with how different JS bundling processes and import syntaxes work, but per the error message above, I noticed that all but one of the places where JS modules are imported in `src` includes the `.js` extension, e.g.

https://github.com/yjs/y-codemirror.next/blob/3f3e1ee9b3ab6992d46e4ca41a6692e799e9b4c3/src/index.js#L6-L8

and when I tested this change in my project, it resolved the importing issue!