### PR TITLE
Add inheritance from `WidgetType` to `YRemoteCaretWidget`

### DIFF
--- a/src/y-remote-selections.js
+++ b/src/y-remote-selections.js
@@ -73,12 +73,13 @@ export const yRemoteSelectionsTheme = EditorView.baseTheme({
  */
 const yRemoteSelectionsAnnotation = Annotation.define()
 
-class YRemoteCaretWidget {
+class YRemoteCaretWidget extends WidgetType {
   /**
    * @param {string} color
    * @param {string} name
    */
   constructor (color, name) {
+    super()
     this.color = color
     this.name = name
   }

--- a/src/y-remote-selections.js
+++ b/src/y-remote-selections.js
@@ -1,5 +1,5 @@
 
-import { ViewPlugin, ViewUpdate, EditorView, Decoration, DecorationSet } from '@codemirror/view' // eslint-disable-line
+import { ViewPlugin, ViewUpdate, EditorView, Decoration, DecorationSet, WidgetType } from '@codemirror/view' // eslint-disable-line
 
 import { RangeSet, Range } from '@codemirror/rangeset' // eslint-disable-line
 import { Annotation, AnnotationType } from '@codemirror/state' // eslint-disable-line


### PR DESCRIPTION
There is no `destroy` method on the `YRemoteCaretWidget` and it sometimes throws a runtime error. I don't have a sufficiently small example that reproduces the error, but I tested the code in the project I'm currently working on.

According to the CodeMirror's author, the decoration widgets in CodeMirror should inherit from the `WidgetType` abstract class. Here is a discussion about it: https://github.com/codemirror/codemirror.next/issues/564#issuecomment-909190245