### PR TITLE
Add undo manager to the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ const ydoc = new Y.Doc()
 const provider = new WebrtcProvider('codemirror6-demo-room', ydoc)
 const ytext = ydoc.getText('codemirror')
 
+const undoManager = new Y.UndoManager(ytext)
+
 provider.awareness.setLocalStateField('user', {
   name: 'Anonymous ' + Math.floor(Math.random() * 100),
   color: userColor.color,
@@ -57,7 +59,7 @@ const state = EditorState.create({
   extensions: [
     basicSetup,
     javascript(),
-    yCollab(ytext, provider.awareness)
+    yCollab(ytext, provider.awareness, { undoManager })
     // oneDark
   ]
 })


### PR DESCRIPTION
When I was reading the README for the first time I was confused about what does "Shared Undo / Redo (each client has its undo-/redo-history) - as a separate plugin" mean. 
There was no example code for the undo manager and the awareness functionality that is also provided as a separate plugin does have an example in the code.

I think that providing the code for a basic `undoManager` can help clarify this confusion.