### PR TITLE
Add zero width non breaking spaces to prevent line wrapping

### DIFF
--- a/src/y-remote-selections.js
+++ b/src/y-remote-selections.js
@@ -26,8 +26,8 @@ export const yRemoteSelectionsTheme = cmView.EditorView.baseTheme({
     boxSizing: 'border-box',
     display: 'inline'
   },
-  '.cm-ySelectionCaret::before': {
-    content: '"\u00a0"', // this is a unicode non-breaking space
+  '.cm-ySelectionCaretTop::before': {
+    content: '"\u2060"', // this is a unicode non-breaking space
     borderRadius: '50%',
     position: 'absolute',
     width: '.4em',
@@ -37,9 +37,15 @@ export const yRemoteSelectionsTheme = cmView.EditorView.baseTheme({
     backgroundColor: 'inherit',
     transition: 'transform .3s ease-in-out'
   },
-  '.cm-ySelectionCaret:hover::before': {
+  '.cm-ySelectionCaret:hover .cm-ySelectionCaretTop::before': {
     transformOrigin: 'bottom center',
     transform: 'scale(0)'
+  },
+  '.cm-ySelectionCaretTop': {
+    backgroundColor: 'inherit',
+    position: 'absolute',
+    top: 0,
+    left: 0
   },
   '.cm-ySelectionInfo': {
     position: 'absolute',
@@ -86,11 +92,17 @@ class YRemoteCaretWidget extends cmView.WidgetType {
 
   toDOM () {
     return /** @type {HTMLElement} */ (dom.element('span', [pair.create('class', 'cm-ySelectionCaret'), pair.create('style', `background-color: ${this.color}; border-color: ${this.color}`)], [
-      dom.element('div', [
-        pair.create('class', 'cm-ySelectionInfo')
-      ], [
-        dom.text(this.name)
-      ])
+        dom.text('\u2060'),
+        dom.element('div', [
+          pair.create('class', 'cm-ySelectionCaretTop')
+        ]),
+        dom.text('\u2060'),
+        dom.element('div', [
+          pair.create('class', 'cm-ySelectionInfo')
+        ], [
+          dom.text(this.name)
+        ]),
+        dom.text('\u2060')
     ]))
   }
 


### PR DESCRIPTION
Hello there,

I'm one of the devs at [hedgedoc](https://hedgedoc.org/) . We plan to use y.js and CM6 for our v2.0 rewrite, so we took a look at this extension. It's great! It covers almost every of our use cases. The only problem we found was, that if line wrapping is activated then the text always gets wrapped at the remote caret. This is a problem because the text doesn't get wrapped in the original editor.

This PR fixes this problem by adding some zero-width-non-breakable-spaces around the remote caret.

How to reproduce the problem:
- Include `EditorView.lineWrapping` in your extensions.
- Use two connected code mirror instances
- Insert "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" into one of them.
- Set the cursor somewhere
- Take a look into the second editor

Thank you for your effort :)