### PR TITLE
Export YRange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,12 @@ import * as Y from 'yjs' // eslint-disable-line
 import * as cmView from '@codemirror/view'
 import * as cmState from '@codemirror/state' // eslint-disable-line
 
+import { YRange } from './y-range.js'
 import { ySync, ySyncFacet, YSyncConfig } from './y-sync.js'
 import { yRemoteSelections, yRemoteSelectionsTheme } from './y-remote-selections.js'
 import { yUndoManager, yUndoManagerFacet, YUndoManagerConfig, undo, redo, yUndoManagerKeymap } from './y-undomanager.js'
 
-export { yRemoteSelections, yRemoteSelectionsTheme, ySync, ySyncFacet, YSyncConfig, yUndoManagerKeymap }
+export { YRange, yRemoteSelections, yRemoteSelectionsTheme, ySync, ySyncFacet, YSyncConfig, yUndoManagerKeymap }
 
 /**
  * @param {Y.Text} ytext


### PR DESCRIPTION
This PR exports the YRange class. Despite being just a wrapper around Y.RelativePosition, I still find the brevity of YRange convenient.

I find it useful to store YRanges in some synced Y.Maps, and being able to call `YRange.fromJSON` and `YRange.toJSON` would be helpful.

Currently, the type itself can be imported from the `dist` directory, but not the actual class value. 