### PR TITLE
Fix ribbon selection for full lines

### DIFF
--- a/src/y-remote-selections.js
+++ b/src/y-remote-selections.js
@@ -214,7 +214,7 @@ export class YRemoteSelectionsPluginValue {
           from: start,
           to: startLine.from + startLine.length,
           value: cmView.Decoration.mark({
-            attributes: { style: `background-color: ${colorLight}` },
+            attributes: { style: `background-color: ${colorLight}; --y-line-selection-color: ${colorLight};` },
             class: 'cm-ySelection'
           })
         })
@@ -223,19 +223,35 @@ export class YRemoteSelectionsPluginValue {
           from: endLine.from,
           to: end,
           value: cmView.Decoration.mark({
-            attributes: { style: `background-color: ${colorLight}` },
+            attributes: { style: `background-color: ${colorLight}; --y-line-selection-color: ${colorLight};` },
             class: 'cm-ySelection'
           })
         })
         for (let i = startLine.number + 1; i < endLine.number; i++) {
-          const linePos = update.view.state.doc.line(i).from
-          decorations.push({
-            from: linePos,
-            to: linePos,
-            value: cmView.Decoration.line({
-              attributes: { style: `background-color: ${colorLight}`, class: 'cm-yLineSelection' }
+          const lineStart = update.view.state.doc.line(i).from;
+          const lineEnd = update.view.state.doc.line(i).to;
+          if (update.view.state.doc.line(i).text.length === 0) {
+            decorations.push({
+              from: lineStart,
+              to: lineEnd,
+              value: cmView.Decoration.line({
+                attributes: { style: `background-color: ${colorLight}; --y-line-selection-color: ${colorLight};`, class: 'cm-yLineSelection cm-yLineSelection-empty' }
+              })
             })
-          })
+          } else {
+            decorations.push({
+              from: lineStart,
+              to: lineEnd,
+              value: cmView.Decoration.mark({
+                attributes: {
+                  style: `background-color: ${colorLight}; --y-line-selection-color: ${colorLight};`,
+                },
+                class: "cm-yLineSelection",
+                tagName: "span",
+                inclusive: true,
+              })
+            })
+          }
         }
       }
       decorations.push({


### PR DESCRIPTION
https://github.com/yjs/y-codemirror.next/issues/8

This fixes the ribbon issue by opting to use marks even for each line (not full line styling) which allows a nested span to be used. 

![image](https://github.com/yjs/y-codemirror.next/assets/4064/839baf7a-7f13-4988-bfdc-57edb60ca87f)

The only case this doesn't work is on blank lines (CM6 ignores decorations on content if the line is blank) which are still treated as line marks. To get these to show you'll need to style them:

```
 .cm-yLineSelection.cm-yLineSelection-empty {
  width: 12px;
}
```

I tried a couple of other approaches where you use only line decorations and style only the children using a color variable, but that led to these cases:

 ![image](https://github.com/yjs/y-codemirror.next/assets/4064/335eca8a-6732-414f-a306-15321fce9681)

Which felt wrong for my app. So I use the line based approach instead. Note: the style variable `--y-line-selection-color` is declared at each line so you can approach this with CSS in your own app.