### PR TITLE
allow external user name/color management

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,16 @@ export { YRange, yRemoteSelections, yRemoteSelectionsTheme, ySync, ySyncFacet, Y
  * @param {any} awareness
  * @param {Object} [opts]
  * @param {Y.UndoManager | false} [opts.undoManager] Set undoManager to false to disable the undo-redo plugin
+ * @param {((u: any) => { name: String, colorLight: String, color: String }) | false} [opts.getUserInfo] Optional fn to take user awareness state info and transform into name + color(s)
  * @return {cmState.Extension}
  */
-export const yCollab = (ytext, awareness, { undoManager = new Y.UndoManager(ytext) } = {}) => {
-  const ySyncConfig = new YSyncConfig(ytext, awareness)
+export const yCollab = (ytext, awareness, { undoManager = new Y.UndoManager(ytext), getUserInfo = false } = {}) => {
+  const ySyncConfig = new YSyncConfig(ytext, awareness, getUserInfo)
   const plugins = [
     ySyncFacet.of(ySyncConfig),
     ySync
   ]
+
   if (awareness) {
     plugins.push(
       yRemoteSelectionsTheme,

--- a/src/y-remote-selections.js
+++ b/src/y-remote-selections.js
@@ -191,8 +191,11 @@ export class YRemoteSelectionsPluginValue {
       if (anchor == null || head == null || anchor.type !== ytext || head.type !== ytext) {
         return
       }
-      const { color = '#30bced', name = 'Anonymous' } = state.user || {}
-      const colorLight = (state.user && state.user.colorLight) || color + '33'
+
+      const userColorAndName = this.conf.getUserInfo ? this.conf.getUserInfo(state.user) : state.user
+      const color = userColorAndName?.color || '#30bced'
+      const name = userColorAndName?.name || 'Anonymous'
+      const colorLight = userColorAndName.colorLight || color + '33'
       const start = math.min(anchor.index, head.index)
       const end = math.max(anchor.index, head.index)
       const startLine = update.view.state.doc.lineAt(start)

--- a/src/y-sync.js
+++ b/src/y-sync.js
@@ -5,10 +5,11 @@ import * as cmView from '@codemirror/view' // eslint-disable-line
 import { YRange } from './y-range.js'
 
 export class YSyncConfig {
-  constructor (ytext, awareness) {
+  constructor (ytext, awareness, getUserInfo) {
     this.ytext = ytext
     this.awareness = awareness
     this.undoManager = new Y.UndoManager(ytext)
+    this.getUserInfo = getUserInfo
   }
 
   /**


### PR DESCRIPTION
in our use case, we have external code that is managing user names and colors. This PR lets you register a `getUserInfo` option which will take whatever you shove in the user's awareness state (like a user id) and return `{ name,color,lightColor }` to use.