### PR TITLE
Export `ySyncAnnotation`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ import * as cmView from '@codemirror/view'
 import * as cmState from '@codemirror/state' // eslint-disable-line
 
 import { YRange } from './y-range.js'
-import { ySync, ySyncFacet, YSyncConfig } from './y-sync.js'
+import { ySync, ySyncFacet, YSyncConfig, ySyncAnnotation } from './y-sync.js'
 import { yRemoteSelections, yRemoteSelectionsTheme } from './y-remote-selections.js'
 import { yUndoManager, yUndoManagerFacet, YUndoManagerConfig, undo, redo, yUndoManagerKeymap } from './y-undomanager.js'
 
-export { YRange, yRemoteSelections, yRemoteSelectionsTheme, ySync, ySyncFacet, YSyncConfig, yUndoManagerKeymap }
+export { YRange, yRemoteSelections, yRemoteSelectionsTheme, ySync, ySyncFacet, YSyncConfig, ySyncAnnotation, yUndoManagerKeymap }
 
 /**
  * @param {Y.Text} ytext


### PR DESCRIPTION
Export the `ySyncAnnotation` CodeMirror annotation type. This allows others to check if a transaction is a remote transaction using code like this:

```ts
import { ySyncAnnotation } from "y-codemirror.next";

function isRemote(tr: Transaction): boolean {
    return !!tr.annotation(ySyncAnnotation);
}
```

Currently this is not possible as the annotation isn't exported by the package `index.js`