### PR TITLE
fix: add path to types in exports definition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     ".": {
       "import": "./src/index.js",
       "module": "./src/index.js",
-      "require": "./dist/y-codemirror.cjs"
+      "require": "./dist/y-codemirror.cjs",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This was breaking my build. It will require a patch version bump to make it function, but there are no changes outside of the package.json and it "just works"

https://github.com/microsoft/TypeScript/issues/52363

> There are types at '/Users/joel/Code/joelhooks/course-builder/apps/course-builder-web/node_modules/y-codemirror.next/dist/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'y-codemirror.next' library may need to update its package.json or typings.