### PR TITLE
fix undo and redo scroll

### DIFF
--- a/src/y-undomanager.js
+++ b/src/y-undomanager.js
@@ -122,14 +122,28 @@ export const yUndoManager = cmView.ViewPlugin.fromClass(YUndoManagerPluginValue)
 /**
  * @type {cmState.StateCommand}
  */
-export const undo = ({ state, dispatch }) =>
-  state.facet(yUndoManagerFacet).undo() || true
+export const undo = ({ state, dispatch }) => {
+  if (state.facet(yUndoManagerFacet).undo()) {
+    dispatch(
+      state.update({
+        effects: [cmView.EditorView.scrollIntoView(state.selection.main)]
+      }))
+  }
+  return true
+}
 
 /**
  * @type {cmState.StateCommand}
  */
-export const redo = ({ state, dispatch }) =>
-  state.facet(yUndoManagerFacet).redo() || true
+export const redo = ({ state, dispatch }) => {
+  if (state.facet(yUndoManagerFacet).redo()) {
+    dispatch(
+      state.update({
+        effects: [cmView.EditorView.scrollIntoView(state.selection.main)]
+      }))
+  }
+  return true
+}
 
 /**
  * @param {cmState.EditorState} state

--- a/src/y-undomanager.js
+++ b/src/y-undomanager.js
@@ -85,7 +85,10 @@ class YUndoManagerPluginValue {
       const sel = stackItem.meta.get(this)
       if (sel) {
         const selection = this.syncConf.fromYRange(sel)
-        view.dispatch(view.state.update({ selection }))
+        view.dispatch(view.state.update({
+          selection,
+          effects: [cmView.EditorView.scrollIntoView(selection)]
+        }))
         this._storeSelection()
       }
     }
@@ -122,28 +125,14 @@ export const yUndoManager = cmView.ViewPlugin.fromClass(YUndoManagerPluginValue)
 /**
  * @type {cmState.StateCommand}
  */
-export const undo = ({ state, dispatch }) => {
-  if (state.facet(yUndoManagerFacet).undo()) {
-    dispatch(
-      state.update({
-        effects: [cmView.EditorView.scrollIntoView(state.selection.main)]
-      }))
-  }
-  return true
-}
+export const undo = ({ state, dispatch }) =>
+  state.facet(yUndoManagerFacet).undo() || true
 
 /**
  * @type {cmState.StateCommand}
  */
-export const redo = ({ state, dispatch }) => {
-  if (state.facet(yUndoManagerFacet).redo()) {
-    dispatch(
-      state.update({
-        effects: [cmView.EditorView.scrollIntoView(state.selection.main)]
-      }))
-  }
-  return true
-}
+export const redo = ({ state, dispatch }) =>
+  state.facet(yUndoManagerFacet).redo() || true
 
 /**
  * @param {cmState.EditorState} state


### PR DESCRIPTION
I think the changes are closer to the native CodeMirror 6 undo/redo scroll behavior, which is first do undo/redo, then move view to the line of cursor by the `nearest` match.

this PR fixes https://github.com/yjs/y-codemirror.next/issues/31
